### PR TITLE
Add NewAmqpCosnumer func

### DIFF
--- a/amqp/amqp.go
+++ b/amqp/amqp.go
@@ -83,15 +83,16 @@ func NewAmqpConsumer(
 	conn *rabbitmq.Conn,
 	routingKey string,
 	queue string,
+	optionFuncs ...func(*rabbitmq.ConsumerOptions),
 ) (*rabbitmq.Consumer, error) {
-	return rabbitmq.NewConsumer(
-		conn,
-		queue,
+	defaultOptions := []func(*rabbitmq.ConsumerOptions){
 		rabbitmq.WithConsumerOptionsRoutingKey(routingKey),
 		rabbitmq.WithConsumerOptionsExchangeName(topic),
-		rabbitmq.WithConsumerOptionsConsumerAutoAck(true),
 		rabbitmq.WithConsumerOptionsLogger(CustomLogger{}),
-	)
+		rabbitmq.WithConsumerOptionsConsumerAutoAck(true),
+	}
+	optionFuncs = append(defaultOptions, optionFuncs...)
+	return rabbitmq.NewConsumer(conn, queue, optionFuncs...)
 }
 
 func StartAmqpPublisher(conn *rabbitmq.Conn) *rabbitmq.Publisher {

--- a/amqp/amqp.go
+++ b/amqp/amqp.go
@@ -79,6 +79,21 @@ func StartAmqpConsumer(conn *rabbitmq.Conn, handler func(rabbitmq.Delivery) rabb
 	return consumer
 }
 
+func NewAmqpConsumer(
+	conn *rabbitmq.Conn,
+	routingKey string,
+	queue string,
+) (*rabbitmq.Consumer, error) {
+	return rabbitmq.NewConsumer(
+		conn,
+		queue,
+		rabbitmq.WithConsumerOptionsRoutingKey(routingKey),
+		rabbitmq.WithConsumerOptionsExchangeName(topic),
+		rabbitmq.WithConsumerOptionsConsumerAutoAck(true),
+		rabbitmq.WithConsumerOptionsLogger(CustomLogger{}),
+	)
+}
+
 func StartAmqpPublisher(conn *rabbitmq.Conn) *rabbitmq.Publisher {
 	publisher, err := rabbitmq.NewPublisher(
 		conn,


### PR DESCRIPTION
I've added new function to amqp package called NewAmqpConsumer. It's a replacement for StartAmqpConsumer that has one problem - it never returns a value, because it calls cosumer.Run method that starts an infinite loop of message processing, so graceful shutdown is impossible for such a consumer.